### PR TITLE
Refactoring the names of test methods

### DIFF
--- a/Legacy/src/test/java/mx/kenzie/foundation/PreFieldTest.java
+++ b/Legacy/src/test/java/mx/kenzie/foundation/PreFieldTest.java
@@ -17,7 +17,7 @@ public class PreFieldTest extends FoundationTest {
 
     /** Checks that the field type is being changed correctly from {@code OBJECT} to {@code BOOLEAN}.*/
     @Test
-    public void testSetType() {
+    public void testWhenSetTypeCalled_typeShouldBeUpdated() {
         final PreField field = new PreField(Object.class, "blob");
         assertEquals(Type.OBJECT, field.type);
         field.setType(boolean.class);
@@ -26,7 +26,7 @@ public class PreFieldTest extends FoundationTest {
 
     /** Checks the setting of the field value and the creation of a method that verifies this value.*/
     @Test
-    public void testSetValue() {
+    public void testWhenSetValueCalled_fieldValueShouldBeSetAndVerifiable() {
         final PreField field = new PreField(PUBLIC, STATIC, FINAL, int.class, "testSetValue");
         field.setValue(10);
 
@@ -40,7 +40,7 @@ public class PreFieldTest extends FoundationTest {
 
     /** Checks the addition of the {@code FINAL} modifier to the field.*/
     @Test
-    public void testAddModifiers() {
+    public void testWhenModifierAdded_fieldShouldHaveThatModifier() {
         final PreField field = new PreField(PUBLIC, STATIC, int.class, "blob");
         assertFalse(field.hasModifier(FINAL));
         field.addModifiers(FINAL);
@@ -49,7 +49,7 @@ public class PreFieldTest extends FoundationTest {
 
     /** Checks for removing the {@code FINAL} modifier from the field.*/
     @Test
-    public void testRemoveModifiers() {
+    public void testWhenModifierRemoved_fieldShouldNotHaveThatModifier() {
         final PreField field = new PreField(PUBLIC, STATIC, FINAL, int.class, "blob");
         assertTrue(field.hasModifier(FINAL));
         field.removeModifiers(FINAL);
@@ -58,7 +58,7 @@ public class PreFieldTest extends FoundationTest {
 
     /** Checks the presence and absence of modifiers {@code (PUBLIC, STATIC, FINAL)} in the field.*/
     @Test
-    public void testHasModifier() {
+    public void testWhenCheckingModifiers_fieldShouldReflectCorrectModifiers() {
         final PreField field = new PreField(PUBLIC, STATIC, int.class, "blob");
         assertFalse(field.hasModifier(FINAL));
         assertTrue(field.hasModifier(PUBLIC));
@@ -74,7 +74,7 @@ public class PreFieldTest extends FoundationTest {
 
     /** Verifies that the field modifier code {@code (PUBLIC, STATIC, FINAL)} is correctly reflected in the {@code modifierCode}.*/
     @Test
-    public void testModifierCode() {
+    public void testWhenModifierCodeChecked_shouldReflectCorrectModifiers() {
         final PreField field = new PreField(PUBLIC, STATIC, FINAL, int.class, "blob");
         assertTrue(Modifier.isPublic(field.modifierCode()));
         assertTrue(Modifier.isStatic(field.modifierCode()));
@@ -84,7 +84,7 @@ public class PreFieldTest extends FoundationTest {
 
     /** Checks the creation of the field and the method that interacts with this field (sets the value and returns the result of the comparison).*/
     @Test
-    public void testBuild() {
+    public void testWhenFieldAndMethodBuilt_shouldInteractCorrectly() {
         final PreField field = new PreField(PUBLIC, STATIC, int.class, "testBuild");
         final AccessField.Stub stub = FIELD.of(thing, "testBuild", int.class);
 


### PR DESCRIPTION
**Clarity**: Each name accurately describes what is being tested.
**Uniform style**: All titles start with ` testWhen...`, which makes them more consistent.
**Easy to read**: The new names help you quickly understand what each test does, without having to delve into its implementation.